### PR TITLE
modify regex for macos

### DIFF
--- a/grep.sh
+++ b/grep.sh
@@ -19,7 +19,8 @@ _grepFindFilesToGrep () {
     -not -wholename '*/node_modules/*'
   )
   # TODO: reuse find.sh functions
-  local langfiles=($(find $_grepLangSearchPATH -regex ".*/$__brain_suffix"'[^/]*[^~]$\|.*'"$__brain_suffix$" $findargs))
+  # This works for me, but don't know why I can't combine the two strings in the first regex.
+  local langfiles=($(find $_grepLangSearchPATH \( -regex ".*/$__brain_suffix""[^/]*[^~]$" -or -regex ".*$__brain_suffix$" \) $findargs))
   local todos=($(find $_grepLangSearchPATH -name "todo" -type f))
   for t in $todos; do langfiles+=$t; done
   #echo "XXX $langfiles" >&2


### PR DESCRIPTION
I tried to concatenate 
`".*/$__brain_suffix""[^/]*[^~]$"` → `".*/$__brain_suffix[^/]*[^~]$"`
in error with
___grepFindFilesToGrep:9: bad math expression: operand expected at `^/'__
and can't find why.
Guessing this should work for linux